### PR TITLE
Fixed edit order commponent at the setControls method

### DIFF
--- a/src/containers/Edit/EditOrder/EditOrder.js
+++ b/src/containers/Edit/EditOrder/EditOrder.js
@@ -51,7 +51,7 @@ class EditOrder extends Component {
     let updatedControls = { ...this.state.controls };
     const { name, address, status, communication } = this.props.OrderToEdit;
     updatedControls.FirstName.value = name.trim().split(" ")[0];
-    updatedControls.LastName.value = name.trim().split(" ")[1];
+    updatedControls.LastName.value = name.split(" ")[1] ? name.trim().split(" ")[1] : " ";
     updatedControls.City.value = address.city;
     updatedControls.Street.value = address.street;
     updatedControls.Number.value = address.number;

--- a/src/shared/Controls/controls.js
+++ b/src/shared/Controls/controls.js
@@ -42,8 +42,7 @@ export const editOrderControls = {
     label: "First Name",
     elementType: "input",
     elementConfig: {
-      type: "text",
-      placeholder: "exemple@site.com",
+      type: "text"
     },
     value: "",
     validation: {
@@ -58,12 +57,11 @@ export const editOrderControls = {
     label: "Last Name",
     elementType: "input",
     elementConfig: {
-      type: "text",
-      placeholder: "exemple@site.com",
+      type: "text"
     },
     value: "",
     validation: {
-      required: true,
+      required: false,
     },
     valid: false,
     touched: false,
@@ -74,8 +72,7 @@ export const editOrderControls = {
     label: "City",
     elementType: "input",
     elementConfig: {
-      type: "text",
-      placeholder: "exemple@site.com",
+      type: "text"
     },
     value: "",
     validation: {
@@ -89,8 +86,7 @@ export const editOrderControls = {
     label: "Street",
     elementType: "input",
     elementConfig: {
-      type: "text",
-      placeholder: "exemple@site.com",
+      type: "text"
     },
     value: "",
     validation: {
@@ -105,8 +101,7 @@ export const editOrderControls = {
     label: "Number",
     elementType: "input",
     elementConfig: {
-      type: "text",
-      placeholder: "exemple@site.com",
+      type: "text"
     },
     value: "",
     validation: {
@@ -121,8 +116,7 @@ export const editOrderControls = {
     label: "Communication",
     elementType: "input",
     elementConfig: {
-      type: "text",
-      placeholder: "exemple@site.com",
+      type: "text"
     },
     value: "",
     validation: {


### PR DESCRIPTION
If client gave us only first name I had to make sure that the FULLNAME input will be initialize with empty string at the componentDidMount.